### PR TITLE
Fix prometheus-client required versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=1.8
 djangorestframework>=3.0
-prometheus-client==0.7.1
+prometheus-client>=0.7.1


### PR DESCRIPTION
From the README.md prometheus-client can be greater or equal (>=) than 0.7.1 but in the requirements is forced to be strictly equal (==) to 0.7.1.
If it is a typo I provide a quick fix with this PR.